### PR TITLE
eslint version to avoid peer dependencies conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-core": "^5.8.20",
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.3.2",
-    "eslint": "^1.0.0",
+    "eslint": "1.0.0",
     "eslint-config-airbnb": "0.0.7",
     "eslint-loader": "^0.14.2",
     "eslint-plugin-react": "^3.2.0",


### PR DESCRIPTION
I have this error when npm install :

peerinvalid Peer eslint-plugin-react@3.2.1 wants eslint@>=0.8.0 || ~1.0.0-rc-0
peerinvalid Peer eslint-loader@0.14.2 wants eslint@0.21 - 0.24 || ~1.0.0-rc-0

"eslint": ^1.0.0 now fetches 1.1.0, not compatible with ~1.0.0-rc-0

but maybe it's better to wait for this packages to update their package.json.
